### PR TITLE
[Refactor] 할인 메뉴 관련 엔티티 수정

### DIFF
--- a/src/main/java/Bob_BE/domain/DiscountMenu/entity/DiscountMenu.java
+++ b/src/main/java/Bob_BE/domain/DiscountMenu/entity/DiscountMenu.java
@@ -1,0 +1,37 @@
+package Bob_BE.domain.DiscountMenu.entity;
+
+import Bob_BE.domain.discount.entity.Discount;
+import Bob_BE.domain.menu.entity.Menu;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@Table(name = "discount_menu")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@DynamicInsert
+@DynamicUpdate
+public class DiscountMenu {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="discount_menu_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private Integer discountPrice;
+
+    @OneToOne
+    @JoinColumn(name = "discount_id")
+    private Discount discount;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "menu_id")
+    private Menu menu;
+}

--- a/src/main/java/Bob_BE/domain/DiscountMenu/entity/DiscountMenu.java
+++ b/src/main/java/Bob_BE/domain/DiscountMenu/entity/DiscountMenu.java
@@ -27,7 +27,7 @@ public class DiscountMenu {
     @Column(nullable = false)
     private Integer discountPrice;
 
-    @OneToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "discount_id")
     private Discount discount;
 

--- a/src/main/java/Bob_BE/domain/discount/entity/Discount.java
+++ b/src/main/java/Bob_BE/domain/discount/entity/Discount.java
@@ -1,6 +1,7 @@
 package Bob_BE.domain.discount.entity;
 
-import Bob_BE.domain.menu.entity.Menu;
+import Bob_BE.domain.DiscountMenu.entity.DiscountMenu;
+import Bob_BE.domain.store.entity.Store;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -31,14 +32,16 @@ public class Discount {
     @Column(nullable = false)
     private LocalDate endDate;
 
-    @Column(nullable = false)
-    private Integer discountPrice;
-
     private String title;
 
-    private String body;
+    private boolean inProgress;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "menu_id")
-    private Menu menu;
+    @JoinColumn(name = "store_id")
+    private Store store;
+
+    @OneToOne(mappedBy = "discount", cascade = CascadeType.ALL)
+    private DiscountMenu discountMenu;
+
+
 }

--- a/src/main/java/Bob_BE/domain/discount/entity/Discount.java
+++ b/src/main/java/Bob_BE/domain/discount/entity/Discount.java
@@ -11,6 +11,8 @@ import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "discount")
@@ -40,8 +42,8 @@ public class Discount {
     @JoinColumn(name = "store_id")
     private Store store;
 
-    @OneToOne(mappedBy = "discount", cascade = CascadeType.ALL)
-    private DiscountMenu discountMenu;
+    @OneToMany(mappedBy = "discount", cascade = CascadeType.ALL)
+    private List<DiscountMenu> discountMenuList = new ArrayList<>();
 
 
 }

--- a/src/main/java/Bob_BE/domain/menu/entity/Menu.java
+++ b/src/main/java/Bob_BE/domain/menu/entity/Menu.java
@@ -1,5 +1,6 @@
 package Bob_BE.domain.menu.entity;
 
+import Bob_BE.domain.DiscountMenu.entity.DiscountMenu;
 import Bob_BE.domain.discount.entity.Discount;
 import Bob_BE.domain.store.entity.Store;
 import jakarta.persistence.*;
@@ -41,6 +42,5 @@ public class Menu {
     private Store store;
 
     @OneToMany(mappedBy = "menu", cascade = CascadeType.ALL)
-    private List<Discount> discountList = new ArrayList<>();
-
+    private List<DiscountMenu> discountMenuList = new ArrayList<>();
 }


### PR DESCRIPTION
## 연관된 이슈
> #7 


</br>

## 작업내용
> 수정 이유 : 할인행사 진행시 메뉴마다 공통속성을 갖는게 많아서 분리 진행 (한번에 시행된 행사가 있을 경우)

![image](https://github.com/user-attachments/assets/8f6a3a6d-b12a-4512-ab19-1c293382a674)

</br>

- 할인행사를 가게와 연결한 후 공통속성은 할인행사로 개별속성은 할인메뉴로 테이블을 분리했습니다.
- 할인진행 여부 변수를 추가하였습니다. - inProgress
- 할인행사와 할인메뉴의 관계는 1대 1입니다.


</br>

> 데이터베이스 업데이트시 필요없는 칼럼 생성시 console로 column을 삭제하시거나 별 데이터가 없으시면 전체 드롭 후 다시보시면 깔끔하실겁니다.
