### PR TITLE
[FEAT] 가게의 메뉴 이름 리스트 가져오기 API 구현

### DIFF
--- a/src/main/java/Bob_BE/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/Bob_BE/domain/menu/repository/MenuRepository.java
@@ -1,8 +1,13 @@
 package Bob_BE.domain.menu.repository;
 
 import Bob_BE.domain.menu.entity.Menu;
+import Bob_BE.domain.store.entity.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface MenuRepository extends JpaRepository<Menu, Long> {
 
+    Optional<List<Menu>> findAllByStore(Store store);
 }

--- a/src/main/java/Bob_BE/domain/menu/service/MenuService.java
+++ b/src/main/java/Bob_BE/domain/menu/service/MenuService.java
@@ -7,18 +7,30 @@ import Bob_BE.domain.menu.dto.response.MenuResponseDto;
 import Bob_BE.domain.menu.dto.response.MenuResponseDto.DeleteMenuResponseDto;
 import Bob_BE.domain.menu.entity.Menu;
 import Bob_BE.domain.menu.repository.MenuRepository;
+import Bob_BE.domain.store.dto.parameter.StoreParameterDto;
+import Bob_BE.domain.store.entity.Store;
+import Bob_BE.domain.store.repository.StoreRepository;
 import Bob_BE.global.response.code.resultCode.ErrorStatus;
 import Bob_BE.global.response.exception.handler.MenuHandler;
+
+import java.util.ArrayList;
 import java.util.List;
+
+import Bob_BE.global.response.exception.handler.StoreHandler;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class MenuService {
 
     private final MenuRepository menuRepository;
+    private final StoreRepository storeRepository;
 
     public MenuResponseDto.CreateMenuResponseDto updateMenu(Long menuId, MenuUpdateRequestDto requestDTO) {
         Menu menu = menuRepository.findById(menuId)
@@ -55,5 +67,17 @@ public class MenuService {
     private String saveImageFile(MultipartFile imageFile) {
         // TODO: 파일 저장 관련 로직 구현
         return "http://example.com/image";
+    }
+
+    @Transactional(readOnly = true)
+    public List<Menu> GetMenuListByStore (@Valid StoreParameterDto.GetMenuNameListParamDto param) {
+
+        Store findStore = storeRepository.findById(param.getStoreId())
+                .orElseThrow(() -> new StoreHandler(ErrorStatus.STORE_NOT_FOUND));
+
+        List<Menu> menuList = menuRepository.findAllByStore(findStore)
+                .orElse(new ArrayList<>());
+
+        return menuList;
     }
 }

--- a/src/main/java/Bob_BE/domain/store/controller/StoreController.java
+++ b/src/main/java/Bob_BE/domain/store/controller/StoreController.java
@@ -2,21 +2,30 @@ package Bob_BE.domain.store.controller;
 
 import Bob_BE.domain.menu.dto.request.MenuRequestDto.MenuCreateRequestDto;
 import Bob_BE.domain.menu.dto.response.MenuResponseDto.CreateMenuResponseDto;
+import Bob_BE.domain.menu.entity.Menu;
+import Bob_BE.domain.menu.service.MenuService;
+import Bob_BE.domain.store.converter.StoreConverter;
+import Bob_BE.domain.store.converter.StoreDtoConverter;
+import Bob_BE.domain.store.dto.parameter.StoreParameterDto;
+import Bob_BE.domain.store.dto.response.StoreResponseDto;
 import Bob_BE.domain.store.service.StoreService;
 import Bob_BE.global.response.ApiResponse;
 import java.util.List;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/v1/stores")
 @RequiredArgsConstructor
 public class StoreController {
+
     private final StoreService storeService;
+    private final MenuService menuService;
 
     @PostMapping("/{storeId}/menus")
     public ApiResponse<List<CreateMenuResponseDto>> createMenus(
@@ -25,5 +34,22 @@ public class StoreController {
     ){
         var response = storeService.createMenus(storeId, requestDto);
         return ApiResponse.onSuccess(response);
+    }
+
+    @GetMapping("/{storeId}/menus-name")
+    @Operation(summary = "가게 메뉴 이름 목록 가져오기 API", description = "가게 메뉴 이름 목록 가져오기 API 입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "STORE404", description = "해당 가게가 존재하지 않습니다.")
+
+    })
+    @Parameters({
+            @Parameter(name = "storeId", description = "가게 식별자, PathVariable")
+    })
+    public ApiResponse<StoreResponseDto.GetMenuNameListResponseDto> GetMenuNameList (@PathVariable("storeId") Long storeId) {
+
+        StoreParameterDto.GetMenuNameListParamDto getMenuNameListParamDto = StoreDtoConverter.INSTANCE.toGetMenuNameListParamDto(storeId);
+        List<Menu> menuList = menuService.GetMenuListByStore(getMenuNameListParamDto);
+        return ApiResponse.onSuccess(StoreConverter.toGetMenuNameListResponseDto(menuList));
     }
 }

--- a/src/main/java/Bob_BE/domain/store/converter/StoreConverter.java
+++ b/src/main/java/Bob_BE/domain/store/converter/StoreConverter.java
@@ -1,0 +1,26 @@
+package Bob_BE.domain.store.converter;
+
+import Bob_BE.domain.menu.entity.Menu;
+import Bob_BE.domain.store.dto.response.StoreResponseDto;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class StoreConverter {
+
+    public static StoreResponseDto.GetMenuNameListResponseDto toGetMenuNameListResponseDto (List<Menu> menuList) {
+
+        List<StoreResponseDto.MenuNameDataDto> menuNameDataDtoList = menuList.stream()
+                .map(menu -> {
+                    return StoreResponseDto.MenuNameDataDto.builder()
+                            .menuId(menu.getId())
+                            .name(menu.getMenuName())
+                            .build();
+                }).collect(Collectors.toList());
+
+        return StoreResponseDto.GetMenuNameListResponseDto.builder()
+                .menuNameDataDtoList(menuNameDataDtoList)
+                .totalDataNum(menuNameDataDtoList.size())
+                .build();
+    }
+}

--- a/src/main/java/Bob_BE/domain/store/converter/StoreDtoConverter.java
+++ b/src/main/java/Bob_BE/domain/store/converter/StoreDtoConverter.java
@@ -1,0 +1,13 @@
+package Bob_BE.domain.store.converter;
+
+import Bob_BE.domain.store.dto.parameter.StoreParameterDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface StoreDtoConverter {
+
+    StoreDtoConverter INSTANCE = Mappers.getMapper(StoreDtoConverter.class);
+
+    StoreParameterDto.GetMenuNameListParamDto toGetMenuNameListParamDto(Long storeId);
+}

--- a/src/main/java/Bob_BE/domain/store/dto/parameter/StoreParameterDto.java
+++ b/src/main/java/Bob_BE/domain/store/dto/parameter/StoreParameterDto.java
@@ -1,0 +1,18 @@
+package Bob_BE.domain.store.dto.parameter;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class StoreParameterDto {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetMenuNameListParamDto {
+
+        private Long storeId;
+    }
+}

--- a/src/main/java/Bob_BE/domain/store/dto/response/StoreResponseDto.java
+++ b/src/main/java/Bob_BE/domain/store/dto/response/StoreResponseDto.java
@@ -1,17 +1,43 @@
 package Bob_BE.domain.store.dto.response;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 public class StoreResponseDto {
+
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
     public static class MenuCreateResultDto {
         private Long id;
+        private String name;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetMenuNameListResponseDto {
+
+        private List<MenuNameDataDto> menuNameDataDtoList;
+        private Integer totalDataNum;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MenuNameDataDto {
+
+        @NotNull
+        private Long menuId;
+        @NotNull
         private String name;
     }
 }

--- a/src/main/java/Bob_BE/domain/store/repository/StoreRepository.java
+++ b/src/main/java/Bob_BE/domain/store/repository/StoreRepository.java
@@ -3,5 +3,9 @@ package Bob_BE.domain.store.repository;
 import Bob_BE.domain.store.entity.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface StoreRepository extends JpaRepository<Store, Long> {
+
 }

--- a/src/main/java/Bob_BE/domain/store/service/StoreService.java
+++ b/src/main/java/Bob_BE/domain/store/service/StoreService.java
@@ -6,21 +6,32 @@ import Bob_BE.domain.menu.dto.request.MenuRequestDto.MenuCreateRequestDto.Create
 import Bob_BE.domain.menu.dto.response.MenuResponseDto;
 import Bob_BE.domain.menu.entity.Menu;
 import Bob_BE.domain.menu.repository.MenuRepository;
+import Bob_BE.domain.store.dto.parameter.StoreParameterDto;
 import Bob_BE.domain.store.entity.Store;
 import Bob_BE.domain.store.repository.StoreRepository;
 import Bob_BE.global.response.code.resultCode.ErrorStatus;
 import Bob_BE.global.response.exception.handler.MenuHandler;
-import java.util.List;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import Bob_BE.global.response.exception.handler.StoreHandler;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class StoreService {
+
     private final StoreRepository storeRepository;
     private final MenuRepository menuRepository;
 
     public List<MenuResponseDto.CreateMenuResponseDto> createMenus(Long storeId, MenuCreateRequestDto requestDto) {
+
         Store store = storeRepository.findById(storeId)
                 .orElseThrow(() -> new MenuHandler(ErrorStatus.STORE_NOT_FOUND));
         List<CreateMenuDto> menus = requestDto.getMenus();
@@ -36,4 +47,5 @@ public class StoreService {
             return MenuConverter.toCreateMenuRegisterResponseDto(newMenu);
         }).toList();
     }
+
 }


### PR DESCRIPTION
## 연관된 이슈
> #6


</br>

## 작업내용
> [할인행사 진행하기] 페이지에 사용될 메뉴 이름 리스트 가져오기 API 구현

</br>

## 데이터베이스 결과
```json
{
  "isSuccess": true,
  "code": "COMMON200",
  "message": "성공입니다.",
  "result": {
    "menuNameDataDtoList": [
      {
        "menuId": 1,
        "name": "test1"
      },
      {
        "menuId": 2,
        "name": "test2"
      },
      {
        "menuId": 3,
        "name": "test3"
      }
    ],
    "totalDataNum": 3
  }
}
```

close #6 