### PR TITLE
[Feat] 가게 등록하기 API

### DIFF
--- a/src/main/java/Bob_BE/domain/store/controller/StoreController.java
+++ b/src/main/java/Bob_BE/domain/store/controller/StoreController.java
@@ -7,11 +7,11 @@ import Bob_BE.domain.menu.service.MenuService;
 import Bob_BE.domain.store.converter.StoreConverter;
 import Bob_BE.domain.store.converter.StoreDtoConverter;
 import Bob_BE.domain.store.dto.parameter.StoreParameterDto;
+import Bob_BE.domain.store.dto.request.StoreRequestDto;
 import Bob_BE.domain.store.dto.response.StoreResponseDto;
 import Bob_BE.domain.store.service.StoreService;
 import Bob_BE.global.response.ApiResponse;
 import java.util.List;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -52,4 +52,21 @@ public class StoreController {
         List<Menu> menuList = menuService.GetMenuListByStore(getMenuNameListParamDto);
         return ApiResponse.onSuccess(StoreConverter.toGetMenuNameListResponseDto(menuList));
     }
+
+    @PostMapping("/{owner_id}")
+    @Operation(summary = "가게 등록 API", description = "가게 정보를 등록하는 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "OWNER404", description = "사장님 정보가 등록되어 있지 않습니다.")
+
+    })
+    @Parameters({
+            @Parameter(name = "ownerId", description = "사장님 Id")
+    })
+    public ApiResponse<StoreResponseDto.StoreCreateResultDto> createStore(@PathVariable("owner_id") Long ownerId, @RequestBody StoreRequestDto.StoreCreateRequestDto requestDto){
+
+
+        return ApiResponse.onSuccess(storeService.createStore(ownerId, requestDto));
+    }
+
 }

--- a/src/main/java/Bob_BE/domain/store/controller/StoreController.java
+++ b/src/main/java/Bob_BE/domain/store/controller/StoreController.java
@@ -57,7 +57,7 @@ public class StoreController {
     }
 
 
-    @PostMapping("/{owner_id}")
+    @PostMapping("/{ownerId}")
     @Operation(summary = "가게 등록 API", description = "가게 정보를 등록하는 API")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
@@ -67,7 +67,7 @@ public class StoreController {
     @Parameters({
             @Parameter(name = "ownerId", description = "사장님 Id")
     })
-    public ApiResponse<StoreResponseDto.StoreCreateResultDto> createStore(@PathVariable("owner_id") Long ownerId, @RequestBody StoreRequestDto.StoreCreateRequestDto requestDto){
+    public ApiResponse<StoreResponseDto.StoreCreateResultDto> createStore(@PathVariable("ownerId") Long ownerId, @RequestBody StoreRequestDto.StoreCreateRequestDto requestDto){
 
 
         return ApiResponse.onSuccess(storeService.createStore(ownerId, requestDto));

--- a/src/main/java/Bob_BE/domain/store/controller/StoreController.java
+++ b/src/main/java/Bob_BE/domain/store/controller/StoreController.java
@@ -2,9 +2,17 @@ package Bob_BE.domain.store.controller;
 
 import Bob_BE.domain.menu.dto.request.MenuRequestDto.MenuCreateRequestDto;
 import Bob_BE.domain.menu.dto.response.MenuResponseDto.CreateMenuResponseDto;
+import Bob_BE.domain.store.dto.request.StoreRequestDto;
+import Bob_BE.domain.store.dto.response.StoreResponseDto;
 import Bob_BE.domain.store.service.StoreService;
 import Bob_BE.global.response.ApiResponse;
 import java.util.List;
+
+import Bob_BE.global.response.code.resultCode.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -26,4 +34,21 @@ public class StoreController {
         var response = storeService.createMenus(storeId, requestDto);
         return ApiResponse.onSuccess(response);
     }
+
+    @PostMapping("/{owner_id}")
+    @Operation(summary = "가게 등록 API", description = "가게 정보를 등록하는 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "OWNER404", description = "사장님 정보가 등록되어 있지 않습니다.")
+
+    })
+    @Parameters({
+            @Parameter(name = "ownerId", description = "사장님 Id")
+    })
+    public ApiResponse<StoreResponseDto.StoreCreateResultDto> createStore(@PathVariable("owner_id") Long ownerId, @RequestBody StoreRequestDto.StoreCreateRequestDto requestDto){
+
+
+        return ApiResponse.onSuccess(storeService.createStore(ownerId, requestDto));
+    }
+
 }

--- a/src/main/java/Bob_BE/domain/store/converter/StoreConverter.java
+++ b/src/main/java/Bob_BE/domain/store/converter/StoreConverter.java
@@ -1,11 +1,14 @@
 package Bob_BE.domain.store.converter;
 
 import Bob_BE.domain.menu.entity.Menu;
-import Bob_BE.domain.store.dto.response.StoreResponseDto;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
+import Bob_BE.domain.owner.entity.Owner;
+import Bob_BE.domain.store.dto.request.StoreRequestDto;
+import Bob_BE.domain.store.dto.response.StoreResponseDto;
+import Bob_BE.domain.store.entity.Store;
 public class StoreConverter {
 
     public static StoreResponseDto.GetMenuNameListResponseDto toGetMenuNameListResponseDto (List<Menu> menuList) {
@@ -21,6 +24,29 @@ public class StoreConverter {
         return StoreResponseDto.GetMenuNameListResponseDto.builder()
                 .menuNameDataDtoList(menuNameDataDtoList)
                 .totalDataNum(menuNameDataDtoList.size())
+                .build();
+    }
+
+
+    public static StoreResponseDto.StoreCreateResultDto toCreateStoreResponseDto(Store store){
+
+        return StoreResponseDto.StoreCreateResultDto.builder()
+                .id(store.getId())
+                .name(store.getName())
+                .build();
+    }
+
+    public static Store toStore(Owner owner, StoreRequestDto.StoreCreateRequestDto requestDto){
+
+        return Store.builder()
+                .owner(owner)
+                .longitude(requestDto.getLongitude())
+                .latitude(requestDto.getLatitude())
+                .name(requestDto.getName())
+                .address(requestDto.getAddress())
+                .streetAddress(requestDto.getStreetAddress())
+                .storeLink(requestDto.getStoreLink())
+                .registration(requestDto.getRegistration())
                 .build();
     }
 }

--- a/src/main/java/Bob_BE/domain/store/converter/StoreConverter.java
+++ b/src/main/java/Bob_BE/domain/store/converter/StoreConverter.java
@@ -1,0 +1,31 @@
+package Bob_BE.domain.store.converter;
+
+import Bob_BE.domain.owner.entity.Owner;
+import Bob_BE.domain.store.dto.request.StoreRequestDto;
+import Bob_BE.domain.store.dto.response.StoreResponseDto;
+import Bob_BE.domain.store.entity.Store;
+
+public class StoreConverter {
+
+    public static StoreResponseDto.StoreCreateResultDto toCreateStoreResponseDto(Store store){
+
+        return StoreResponseDto.StoreCreateResultDto.builder()
+                .id(store.getId())
+                .name(store.getName())
+                .build();
+    }
+
+    public static Store toStore(Owner owner, StoreRequestDto.StoreCreateRequestDto requestDto){
+
+        return Store.builder()
+                .owner(owner)
+                .longitude(requestDto.getLongitude())
+                .latitude(requestDto.getLatitude())
+                .name(requestDto.getName())
+                .address(requestDto.getAddress())
+                .streetAddress(requestDto.getStreetAddress())
+                .storeLink(requestDto.getStoreLink())
+                .registration(requestDto.getRegistration())
+                .build();
+    }
+}

--- a/src/main/java/Bob_BE/domain/store/dto/request/StoreRequestDto.java
+++ b/src/main/java/Bob_BE/domain/store/dto/request/StoreRequestDto.java
@@ -1,0 +1,25 @@
+package Bob_BE.domain.store.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class StoreRequestDto {
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    @Builder
+    public static class StoreCreateRequestDto{
+        private String name;
+        private Double longitude;
+        private Double latitude;
+        private String address;
+        private String streetAddress;
+        private String storeLink;
+        private String registration;
+        private String university;
+    }
+}

--- a/src/main/java/Bob_BE/domain/store/dto/response/StoreResponseDto.java
+++ b/src/main/java/Bob_BE/domain/store/dto/response/StoreResponseDto.java
@@ -40,4 +40,12 @@ public class StoreResponseDto {
         @NotNull
         private String name;
     }
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class StoreCreateResultDto {
+        private Long id;
+        private String name;
+    }
 }

--- a/src/main/java/Bob_BE/domain/store/dto/response/StoreResponseDto.java
+++ b/src/main/java/Bob_BE/domain/store/dto/response/StoreResponseDto.java
@@ -14,4 +14,13 @@ public class StoreResponseDto {
         private Long id;
         private String name;
     }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class StoreCreateResultDto {
+        private Long id;
+        private String name;
+    }
 }

--- a/src/main/java/Bob_BE/domain/store/repository/StoreRepository.java
+++ b/src/main/java/Bob_BE/domain/store/repository/StoreRepository.java
@@ -4,4 +4,5 @@ import Bob_BE.domain.store.entity.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StoreRepository extends JpaRepository<Store, Long> {
+
 }

--- a/src/main/java/Bob_BE/domain/store/service/StoreService.java
+++ b/src/main/java/Bob_BE/domain/store/service/StoreService.java
@@ -6,20 +6,42 @@ import Bob_BE.domain.menu.dto.request.MenuRequestDto.MenuCreateRequestDto.Create
 import Bob_BE.domain.menu.dto.response.MenuResponseDto;
 import Bob_BE.domain.menu.entity.Menu;
 import Bob_BE.domain.menu.repository.MenuRepository;
+import Bob_BE.domain.owner.entity.Owner;
+import Bob_BE.domain.owner.repository.OwnerRepository;
+import Bob_BE.domain.store.converter.StoreConverter;
+import Bob_BE.domain.store.dto.request.StoreRequestDto;
+import Bob_BE.domain.store.dto.response.StoreResponseDto;
 import Bob_BE.domain.store.entity.Store;
 import Bob_BE.domain.store.repository.StoreRepository;
+import Bob_BE.domain.storeUniversity.entity.StoreUniversity;
+import Bob_BE.domain.storeUniversity.repository.StoreUniversityRepository;
+import Bob_BE.domain.storeUniversity.service.StoreUniversityService;
+import Bob_BE.domain.university.entity.University;
+import Bob_BE.domain.university.repository.UniversityRepository;
 import Bob_BE.global.response.code.resultCode.ErrorStatus;
 import Bob_BE.global.response.exception.handler.MenuHandler;
+
+import java.io.UncheckedIOException;
 import java.util.List;
+
+import Bob_BE.global.response.exception.handler.OwnerHandler;
+import Bob_BE.global.response.exception.handler.UniversityHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class StoreService {
     private final StoreRepository storeRepository;
     private final MenuRepository menuRepository;
+    private final OwnerRepository ownerRepository;
 
+    private final StoreUniversityService storeUniversityService;
+
+
+    @Transactional
     public List<MenuResponseDto.CreateMenuResponseDto> createMenus(Long storeId, MenuCreateRequestDto requestDto) {
         Store store = storeRepository.findById(storeId)
                 .orElseThrow(() -> new MenuHandler(ErrorStatus.STORE_NOT_FOUND));
@@ -35,5 +57,17 @@ public class StoreService {
             newMenu = menuRepository.save(newMenu);
             return MenuConverter.toCreateMenuRegisterResponseDto(newMenu);
         }).toList();
+    }
+
+    @Transactional
+    public StoreResponseDto.StoreCreateResultDto createStore(Long ownerId, StoreRequestDto.StoreCreateRequestDto requestDto){
+        Owner findOwner = ownerRepository.findById(ownerId).orElseThrow(() -> new OwnerHandler(ErrorStatus.OWNER_NOT_FOUND));
+
+        Store newStore = StoreConverter.toStore(findOwner, requestDto);
+
+        storeUniversityService.saveStoreUniversity(newStore, requestDto.getUniversity());
+        storeRepository.save(newStore);
+
+        return StoreConverter.toCreateStoreResponseDto(newStore);
     }
 }

--- a/src/main/java/Bob_BE/domain/storeUniversity/repository/StoreUniversityRepository.java
+++ b/src/main/java/Bob_BE/domain/storeUniversity/repository/StoreUniversityRepository.java
@@ -1,0 +1,8 @@
+package Bob_BE.domain.storeUniversity.repository;
+
+import Bob_BE.domain.storeUniversity.entity.StoreUniversity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoreUniversityRepository extends JpaRepository<StoreUniversity, Long> {
+
+}

--- a/src/main/java/Bob_BE/domain/storeUniversity/service/StoreUniversityService.java
+++ b/src/main/java/Bob_BE/domain/storeUniversity/service/StoreUniversityService.java
@@ -1,0 +1,32 @@
+package Bob_BE.domain.storeUniversity.service;
+
+import Bob_BE.domain.store.entity.Store;
+import Bob_BE.domain.storeUniversity.entity.StoreUniversity;
+import Bob_BE.domain.storeUniversity.repository.StoreUniversityRepository;
+import Bob_BE.domain.university.entity.University;
+import Bob_BE.domain.university.repository.UniversityRepository;
+import Bob_BE.global.response.code.resultCode.ErrorStatus;
+import Bob_BE.global.response.exception.handler.UniversityHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class StoreUniversityService {
+    private final StoreUniversityRepository storeUniversityRepository;
+    private final UniversityRepository universityRepository;
+
+    @Transactional
+    public void saveStoreUniversity(Store store, String universityName){
+        University university = universityRepository.findByUniversityName(universityName).orElseThrow(()->new UniversityHandler(ErrorStatus.UNIVERSITY_NOT_FOUND));
+
+        StoreUniversity storeUniversity = StoreUniversity.builder()
+                .university(university)
+                .store(store)
+                .build();
+
+        storeUniversityRepository.save(storeUniversity);
+    }
+
+}

--- a/src/main/java/Bob_BE/domain/university/repository/UniversityRepository.java
+++ b/src/main/java/Bob_BE/domain/university/repository/UniversityRepository.java
@@ -1,0 +1,10 @@
+package Bob_BE.domain.university.repository;
+
+import Bob_BE.domain.university.entity.University;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UniversityRepository extends JpaRepository<University, Long> {
+    Optional<University> findByUniversityName(String universityName);
+}

--- a/src/main/java/Bob_BE/global/response/code/resultCode/ErrorStatus.java
+++ b/src/main/java/Bob_BE/global/response/code/resultCode/ErrorStatus.java
@@ -21,11 +21,18 @@ public enum ErrorStatus implements BaseErrorCode {
     MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "MENU404", "해당 메뉴가 존재하지않습니다."),
 
     // Store
-    STORE_NOT_FOUND(HttpStatus.BAD_REQUEST, "STORE404", "해당하는 가게가 존재하지않습니다."),
+    STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "STORE400", "해당하는 가게가 존재하지않습니다."),
+    STORE_BAD_REQUEST(HttpStatus.BAD_REQUEST, "STORE400", "이미 등록된 주소입니다."),
 
     // Discount
     DISCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "DISCOUNT401", "해당 할인 행사가 존재하지 않습니다."),
     DISCOUNT_STORE_NOT_MATCH(HttpStatus.BAD_REQUEST, "DISCOUNT402", "해당 가게의 할인 행사가 아닙니다."),
+
+    // Owner
+    OWNER_NOT_FOUND(HttpStatus.NOT_FOUND, "OWNER404", "사장님 정보가 등록되어 있지 않습니다."),
+
+    // University
+    UNIVERSITY_NOT_FOUND(HttpStatus.NOT_FOUND, "UNIVERSITY404", "등록되지 않은 학교입니다."),
 
     ;
 

--- a/src/main/java/Bob_BE/global/response/code/resultCode/ErrorStatus.java
+++ b/src/main/java/Bob_BE/global/response/code/resultCode/ErrorStatus.java
@@ -21,7 +21,7 @@ public enum ErrorStatus implements BaseErrorCode {
     MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "MENU404", "해당 메뉴가 존재하지않습니다."),
 
     // Store
-    STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "STORE400", "해당하는 가게가 존재하지않습니다."),
+    STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "STORE404", "해당하는 가게가 존재하지않습니다."),
     STORE_BAD_REQUEST(HttpStatus.BAD_REQUEST, "STORE400", "이미 등록된 주소입니다."),
 
     // Discount

--- a/src/main/java/Bob_BE/global/response/exception/handler/OwnerHandler.java
+++ b/src/main/java/Bob_BE/global/response/exception/handler/OwnerHandler.java
@@ -1,0 +1,11 @@
+package Bob_BE.global.response.exception.handler;
+
+import Bob_BE.global.response.code.BaseErrorCode;
+import Bob_BE.global.response.exception.GeneralException;
+
+public class OwnerHandler extends GeneralException {
+
+    public OwnerHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/Bob_BE/global/response/exception/handler/UniversityHandler.java
+++ b/src/main/java/Bob_BE/global/response/exception/handler/UniversityHandler.java
@@ -1,0 +1,11 @@
+package Bob_BE.global.response.exception.handler;
+
+import Bob_BE.global.response.code.BaseErrorCode;
+import Bob_BE.global.response.exception.GeneralException;
+
+public class UniversityHandler extends GeneralException {
+
+    public UniversityHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}


### PR DESCRIPTION
## 연관된 이슈
> ex) #11

> #19 pr과 작업한 디렉토리가 겹쳐 충돌이 많을 것으로 예상되는데 일단 pr 올리고 머지할 때 수정하겠습니다.

</br>

## 작업내용
> 무엇을 개발하였는지와 기능의 코드를 설명해주세요.

>가게 등록하기 API.
- 대학교는 더미 데이터로 디비 상에 직접 입력된 상태로 동작하도록 했습니다.
- store_university 테이블에 관한 정보도 가게 등록 시 같이 저장되도록 했습니다.


</br>

## 데이터베이스 결과
> 코드 블럭 <json>으로 보여주세요.
```json
{
  "isSuccess": true,
  "code": "COMMON200",
  "message": "성공입니다.",
  "result": {
    "id": 1,
    "name": "시장을여는사람들"
  }
}
``` 
