### PR TITLE
[Feat] 배너 이미지 등록

### DIFF
--- a/src/main/java/Bob_BE/domain/banner/entity/Banner.java
+++ b/src/main/java/Bob_BE/domain/banner/entity/Banner.java
@@ -6,12 +6,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
 @Entity
 @Table(name = "banner")
 @Getter
+@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor

--- a/src/main/java/Bob_BE/domain/banner/repository/BannerRepository.java
+++ b/src/main/java/Bob_BE/domain/banner/repository/BannerRepository.java
@@ -1,0 +1,7 @@
+package Bob_BE.domain.banner.repository;
+
+import Bob_BE.domain.banner.entity.Banner;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BannerRepository extends JpaRepository<Banner, Long> {
+}

--- a/src/main/java/Bob_BE/domain/owner/service/OwnerService.java
+++ b/src/main/java/Bob_BE/domain/owner/service/OwnerService.java
@@ -66,4 +66,16 @@ public class OwnerService {
             throw new GeneralException(ErrorStatus.INTERNAL_SERVER_ERROR);
         }
     }
+
+    public Long getOwnerIdFromJwt(String authorizationHeader) {
+        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+            throw new GeneralException(ErrorStatus.MISSING_JWT_EXCEPTION);
+        }
+        String jwtToken = authorizationHeader.substring(7);
+        boolean isValidToken = jwtTokenProvider.isValidateToken(jwtToken);
+        if (!isValidToken) {
+            throw new GeneralException(ErrorStatus.EXPIRED_JWT_EXCEPTION);
+        }
+        return jwtTokenProvider.getId(jwtToken);
+    }
 }

--- a/src/main/java/Bob_BE/domain/store/controller/StoreController.java
+++ b/src/main/java/Bob_BE/domain/store/controller/StoreController.java
@@ -5,6 +5,7 @@ import Bob_BE.domain.menu.dto.response.MenuResponseDto.CreateMenuResponseDto;
 
 import Bob_BE.domain.menu.entity.Menu;
 import Bob_BE.domain.menu.service.MenuService;
+import Bob_BE.domain.owner.service.OwnerService;
 import Bob_BE.domain.store.converter.StoreConverter;
 import Bob_BE.domain.store.converter.StoreDtoConverter;
 import Bob_BE.domain.store.dto.parameter.StoreParameterDto;
@@ -30,6 +31,7 @@ public class StoreController {
 
     private final StoreService storeService;
     private final MenuService menuService;
+    private final OwnerService ownerService;
 
     @PostMapping("/{storeId}/menus")
     @Operation(summary = "메뉴 추가 API", description = "가게에 새로운 메뉴들을 추가하는 API입니다.")
@@ -66,17 +68,19 @@ public class StoreController {
     }
 
 
-    @PostMapping("/{ownerId}")
+    @PostMapping
+    @Operation(summary = "가게 등록 API", description = "가게 정보를 등록하는 API")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다."),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "OWNER404", description = "유저 정보가 존재하지 않습니다.")
     })
     public ApiResponse<StoreResponseDto.StoreCreateResultDto> createStore(
-            @PathVariable("ownerId") Long ownerId,
+            @RequestHeader(value = "Authorization",required = false) String authorizationHeader,
             @RequestPart("store") StoreRequestDto.StoreCreateRequestDto requestDto,
             @RequestPart(value = "bannerFiles", required = false) MultipartFile[] bannerFiles
     ){
+        Long ownerId = ownerService.getOwnerIdFromJwt(authorizationHeader);
         StoreResponseDto.StoreCreateResultDto responseDto = storeService.createStore(ownerId, requestDto, bannerFiles);
         return ApiResponse.onSuccess(responseDto);
     }

--- a/src/main/java/Bob_BE/domain/store/controller/StoreController.java
+++ b/src/main/java/Bob_BE/domain/store/controller/StoreController.java
@@ -82,7 +82,7 @@ public class StoreController {
             @RequestParam("storeLink") String storeLink,
             @RequestParam("registration") String registration,
             @RequestParam("university") String university,
-            @RequestParam(value="bannerFile", required = false)MultipartFile bannerFile
+            @RequestParam(value="bannerFiles", required = false)MultipartFile[] bannerFiles
             ){
         StoreRequestDto.StoreCreateRequestDto requestDto = StoreCreateRequestDto.builder()
                 .name(name)
@@ -95,7 +95,7 @@ public class StoreController {
                 .university(university)
                 .build();
 
-        StoreResponseDto.StoreCreateResultDto responseDto = storeService.createStore(ownerId, requestDto, bannerFile);
+        StoreResponseDto.StoreCreateResultDto responseDto = storeService.createStore(ownerId, requestDto, bannerFiles);
         return ApiResponse.onSuccess(responseDto);
     }
 

--- a/src/main/java/Bob_BE/domain/store/controller/StoreController.java
+++ b/src/main/java/Bob_BE/domain/store/controller/StoreController.java
@@ -9,6 +9,7 @@ import Bob_BE.domain.store.converter.StoreConverter;
 import Bob_BE.domain.store.converter.StoreDtoConverter;
 import Bob_BE.domain.store.dto.parameter.StoreParameterDto;
 import Bob_BE.domain.store.dto.request.StoreRequestDto;
+import Bob_BE.domain.store.dto.request.StoreRequestDto.StoreCreateRequestDto;
 import Bob_BE.domain.store.dto.response.StoreResponseDto;
 import Bob_BE.domain.store.service.StoreService;
 import Bob_BE.global.response.ApiResponse;
@@ -20,6 +21,7 @@ import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/v1/stores")
@@ -65,19 +67,36 @@ public class StoreController {
 
 
     @PostMapping("/{ownerId}")
-    @Operation(summary = "가게 등록 API", description = "가게 정보를 등록하는 API")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "OWNER404", description = "사장님 정보가 등록되어 있지 않습니다.")
-
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "OWNER404", description = "가게 정보가 존재하지 않습니다.")
     })
-    @Parameters({
-            @Parameter(name = "ownerId", description = "사장님 Id")
-    })
-    public ApiResponse<StoreResponseDto.StoreCreateResultDto> createStore(@PathVariable("ownerId") Long ownerId, @RequestBody StoreRequestDto.StoreCreateRequestDto requestDto){
+    public ApiResponse<StoreResponseDto.StoreCreateResultDto> createStore(
+            @PathVariable Long ownerId,
+            @RequestParam("name") String name,
+            @RequestParam("latitude") Double latitude,
+            @RequestParam("longitude") Double longitude,
+            @RequestParam("address") String address,
+            @RequestParam("streetAddress") String streetAddress,
+            @RequestParam("storeLink") String storeLink,
+            @RequestParam("registration") String registration,
+            @RequestParam("university") String university,
+            @RequestParam(value="bannerFile", required = false)MultipartFile bannerFile
+            ){
+        StoreRequestDto.StoreCreateRequestDto requestDto = StoreCreateRequestDto.builder()
+                .name(name)
+                .latitude(latitude)
+                .longitude(longitude)
+                .address(address)
+                .streetAddress(streetAddress)
+                .storeLink(storeLink)
+                .registration(registration)
+                .university(university)
+                .build();
 
-
-        return ApiResponse.onSuccess(storeService.createStore(ownerId, requestDto));
+        StoreResponseDto.StoreCreateResultDto responseDto = storeService.createStore(ownerId, requestDto, bannerFile);
+        return ApiResponse.onSuccess(responseDto);
     }
 
     @PatchMapping("/{storeId}")

--- a/src/main/java/Bob_BE/domain/store/controller/StoreController.java
+++ b/src/main/java/Bob_BE/domain/store/controller/StoreController.java
@@ -70,31 +70,13 @@ public class StoreController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다."),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "OWNER404", description = "가게 정보가 존재하지 않습니다.")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "OWNER404", description = "유저 정보가 존재하지 않습니다.")
     })
     public ApiResponse<StoreResponseDto.StoreCreateResultDto> createStore(
-            @PathVariable Long ownerId,
-            @RequestParam("name") String name,
-            @RequestParam("latitude") Double latitude,
-            @RequestParam("longitude") Double longitude,
-            @RequestParam("address") String address,
-            @RequestParam("streetAddress") String streetAddress,
-            @RequestParam("storeLink") String storeLink,
-            @RequestParam("registration") String registration,
-            @RequestParam("university") String university,
-            @RequestParam(value="bannerFiles", required = false)MultipartFile[] bannerFiles
-            ){
-        StoreRequestDto.StoreCreateRequestDto requestDto = StoreCreateRequestDto.builder()
-                .name(name)
-                .latitude(latitude)
-                .longitude(longitude)
-                .address(address)
-                .streetAddress(streetAddress)
-                .storeLink(storeLink)
-                .registration(registration)
-                .university(university)
-                .build();
-
+            @PathVariable("ownerId") Long ownerId,
+            @RequestPart("store") StoreRequestDto.StoreCreateRequestDto requestDto,
+            @RequestPart(value = "bannerFiles", required = false) MultipartFile[] bannerFiles
+    ){
         StoreResponseDto.StoreCreateResultDto responseDto = storeService.createStore(ownerId, requestDto, bannerFiles);
         return ApiResponse.onSuccess(responseDto);
     }

--- a/src/main/java/Bob_BE/domain/store/controller/StoreController.java
+++ b/src/main/java/Bob_BE/domain/store/controller/StoreController.java
@@ -73,7 +73,9 @@ public class StoreController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다."),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "OWNER404", description = "유저 정보가 존재하지 않습니다.")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "OWNER404", description = "유저 정보가 존재하지 않습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "OAUTH401", description = "JWT 토큰 만료"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "OAUTH404", description = "JWT 토큰 없음")
     })
     public ApiResponse<StoreResponseDto.StoreCreateResultDto> createStore(
             @RequestHeader(value = "Authorization",required = false) String authorizationHeader,

--- a/src/main/java/Bob_BE/domain/store/converter/StoreConverter.java
+++ b/src/main/java/Bob_BE/domain/store/converter/StoreConverter.java
@@ -56,10 +56,14 @@ public class StoreConverter {
 
 
     public static StoreResponseDto.StoreCreateResultDto toCreateStoreResponseDto(Store store){
+        List<String> bannerImageUrls = store.getBannerList().stream()
+                .map(banner -> banner.getBannerUrl())
+                .collect(Collectors.toList());
 
         return StoreResponseDto.StoreCreateResultDto.builder()
                 .id(store.getId())
                 .name(store.getName())
+                .bannerImageUrls(bannerImageUrls)
                 .build();
     }
 

--- a/src/main/java/Bob_BE/domain/store/dto/response/StoreResponseDto.java
+++ b/src/main/java/Bob_BE/domain/store/dto/response/StoreResponseDto.java
@@ -1,5 +1,6 @@
 package Bob_BE.domain.store.dto.response;
 
+import Bob_BE.domain.banner.entity.Banner;
 import Bob_BE.domain.discount.entity.Discount;
 import Bob_BE.domain.store.entity.Store;
 import com.querydsl.core.annotations.QueryProjection;
@@ -49,6 +50,7 @@ public class StoreResponseDto {
     public static class StoreCreateResultDto {
         private Long id;
         private String name;
+        private List<String> bannerImageUrls;
     }
 
     @Getter

--- a/src/main/java/Bob_BE/domain/store/entity/Store.java
+++ b/src/main/java/Bob_BE/domain/store/entity/Store.java
@@ -21,6 +21,7 @@ import java.util.List;
 @Entity
 @Table(name = "store")
 @Getter
+@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor

--- a/src/main/java/Bob_BE/domain/store/service/StoreService.java
+++ b/src/main/java/Bob_BE/domain/store/service/StoreService.java
@@ -20,6 +20,7 @@ import Bob_BE.domain.university.entity.University;
 import Bob_BE.domain.university.repository.UniversityRepository;
 import Bob_BE.domain.storeUniversity.service.StoreUniversityService;
 import Bob_BE.global.response.code.resultCode.ErrorStatus;
+import Bob_BE.global.response.exception.handler.ImageHandler;
 import Bob_BE.global.response.exception.handler.MenuHandler;
 
 import Bob_BE.global.util.aws.S3StorageService;
@@ -96,7 +97,7 @@ public class StoreService {
                     banners.add(banner);
                     bannerRepository.save(banner);
                 }catch (IOException e){
-                    throw new StoreHandler(ErrorStatus.FILE_UPLOAD_FAILED);
+                    throw new ImageHandler(ErrorStatus.FILE_UPLOAD_FAILED);
                 }
             }
         }

--- a/src/main/java/Bob_BE/global/response/code/resultCode/ErrorStatus.java
+++ b/src/main/java/Bob_BE/global/response/code/resultCode/ErrorStatus.java
@@ -14,6 +14,10 @@ public enum ErrorStatus implements BaseErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "GLOBAL401", "서버 오류"),
     KAKAO_TOKEN_ERROR(HttpStatus.BAD_REQUEST, "GLOBAL402", "토큰관련 서버 에러"),
 
+    // OAuth
+    EXPIRED_JWT_EXCEPTION(HttpStatus.UNAUTHORIZED, "OAUTH401", "JWT 토큰 만료"),
+    MISSING_JWT_EXCEPTION(HttpStatus.UNAUTHORIZED, "OAUTH404", "JWT 토큰 없음"),
+
     // User
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER401", "해당 유저가 존재하지 않습니다." ),
 

--- a/src/main/java/Bob_BE/global/response/exception/handler/ImageHandler.java
+++ b/src/main/java/Bob_BE/global/response/exception/handler/ImageHandler.java
@@ -1,0 +1,11 @@
+package Bob_BE.global.response.exception.handler;
+
+import Bob_BE.global.response.code.BaseErrorCode;
+import Bob_BE.global.response.exception.GeneralException;
+
+
+public class ImageHandler extends GeneralException {
+    public ImageHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}


### PR DESCRIPTION
## 연관된 이슈
> ex) #43 

</br>

## 작업내용
> 무엇을 개발하였는지와 기능의 코드를 설명해주세요.
- 가게 등록시 배너 이미지 까지 포함한 멀티파트 요청 생성

### 상세
1. 가게와 배너 이미지 테이블은 1대 다 관계로 되어있습니다. 이에 따라 현재 api 엔드포인트를 다음과 같이 변경해야 한다고 생각합니다.
    
    1. 기존
        1. `/v1/stores/banner [parameter multiPart]`
    2. 변경
        1. `/v1/stores/{store_id}/banner [parameter multiPart]`
2. 하지만 `{storeId}` 는 메뉴 등록 과정 중 생성되지 않는 문제를 가지고 있습니다. 따라서 다음과 같은 동작을 제안합니다.
    
    1. `/v1/stores/{owner_id} [parameter multiPart]` (기존 가게 등록 폼에 통합 / 멀티파트 폼 사용)
3. 기본 정보 입력    
    1. 가게 정보 업로드 (POST `v1/stores/{ownerId}`)
    
    ```text
    //Request Header (멀티파트 폼)
    
    Request Headers:
    Content-Type: multipart/form-data
    
    //Response
    
    {
    	"storeId" : Long,
    	"name" : "밥이득 김치찌개",
    	"bannerUrl" : [s3 URL]
    	...
    }
    ```

</br>

## 요청 헤더
<img width="806" alt="스크린샷 2024-08-03 오후 4 48 13" src="https://github.com/user-attachments/assets/da61bc24-0534-4ba1-aeaa-b30685cd196f">


## 요청 폼
<img width="826" alt="스크린샷 2024-08-03 오후 4 48 31" src="https://github.com/user-attachments/assets/fb213584-f1c3-46a8-a3e0-ffb308f36321">

## 데이터베이스 결과

```json
{
    "isSuccess": true,
    "code": "COMMON200",
    "message": "성공입니다.",
    "result": {
        "id": 13,
        "name": "밥이득 김치찌개5",
        "bannerImageUrls": [
            "https://bab-e-deuk-bucket.s3.ap-northeast-2.amazonaws.com/Banners/79be8ad1-1f9b-4c3a-9290-fa9f13325250-%E1%84%80%E1%85%B5%E1%86%B7%E1%84%8E%E1%85%B5%E1%84%8D%E1%85%B5%E1%84%80%E1%85%A2.jpeg",
            "https://bab-e-deuk-bucket.s3.ap-northeast-2.amazonaws.com/Banners/c009eb85-953d-42ef-b96c-f7b58c40a490-dalle.webp",
            "https://bab-e-deuk-bucket.s3.ap-northeast-2.amazonaws.com/Banners/4564ac80-ce9c-4608-97af-151e542339dc-basic_logo.png"
        ]
    }
}
```
