### PR TITLE
[FIX]: 카카오 소셜 로그인 수정

### DIFF
--- a/src/main/java/Bob_BE/global/external/KakaoAuthClient.java
+++ b/src/main/java/Bob_BE/global/external/KakaoAuthClient.java
@@ -1,0 +1,19 @@
+package Bob_BE.global.external;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "KakaoAuth" , url = "https://kauth.kakao.com")
+public interface KakaoAuthClient {
+    @PostMapping(path = "/oauth/token",
+            consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE + ";charset=utf-8")
+    KakaoResponseDto.KakaoTokenResponseDto getAccessToken(
+            @RequestParam("client_id") String clientId,
+            @RequestParam("client_secret") String clientSecret,
+            @RequestParam("grant_type") String grantType,
+            @RequestParam("redirect_uri") String redirectUri,
+            @RequestParam("code") String authorizationCode
+    );
+}

--- a/src/main/java/Bob_BE/global/external/KakaoResponseDto.java
+++ b/src/main/java/Bob_BE/global/external/KakaoResponseDto.java
@@ -1,11 +1,28 @@
 package Bob_BE.global.external;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
 
 public class KakaoResponseDto {
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @ToString
+    public static class KakaoTokenResponseDto {
+        @JsonProperty("access_token")
+        private String accessToken;
+        @JsonProperty("token_type")
+        private String tokenType;
+        @JsonProperty("refresh_token")
+        private String refreshToken;
+        @JsonProperty("expires_in")
+        private int expiresIn;
+        private String scope;
+        @JsonProperty("refresh_token_expires_in")
+        private int refreshTokenExpiresIn;
+    }
+
     @Getter
     @Builder
     @NoArgsConstructor

--- a/src/main/java/Bob_BE/global/external/KakaoUserClient.java
+++ b/src/main/java/Bob_BE/global/external/KakaoUserClient.java
@@ -6,10 +6,12 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 
-@FeignClient(name = "KakaoUser" , url = "https://kapi.kakao.com/v2/user/me")
+@FeignClient(name = "KakaoUser" , url = "https://kapi.kakao.com")
 public interface KakaoUserClient {
-    @GetMapping(consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    @GetMapping(path = "/v2/user/me", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
     KakaoResponseDto.KakaoUserResponseDto getUserInfo(
             @RequestHeader(HttpHeaders.AUTHORIZATION) String authorization
     );
+
+
 }


### PR DESCRIPTION
## 연관된 이슈
> ex) #90 


</br>

## 작업내용
> 카카오 소셜 로그인에서 인가코드를 받아 로그인할 수 있도록 수정,
학생, 사장 소셜 로그인 수정

</br>

## 데이터베이스 결과
> 결과는 기존 응답과 달라진 점이 없습니다. 
```
{
  "isSuccess": true,
  "code": "COMMON200",
  "message": "성공입니다.",
  "result": {
    "successStatus": "_OK",
    "jwt": "eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MiwiaWF0IjoxNzIzMzgwMzk1LCJleHAiOjE3MjMzODM5OTV9.nTXYZqwAJtiH9Fmk-gADm7awsBWCkDe-ikaz1Xy0NIc"
  }
}
```