### PR TITLE
fix: 오늘의 할인식당 식당기준으로 그룹화

### DIFF
--- a/src/main/java/Bob_BE/domain/store/repository/StoreCustomRepository.java
+++ b/src/main/java/Bob_BE/domain/store/repository/StoreCustomRepository.java
@@ -8,5 +8,6 @@ import java.util.List;
 public interface StoreCustomRepository {
 
     List<StoreResponseDto.StoreAndDiscountDataDto> GetOnSaleStoreAndDiscount(University university);
+    List<StoreResponseDto.StoreAndDiscountDataDto> GetOnSaleStore(University university);
     List<StoreResponseDto.GetOnSaleStoreDataDto> GetOnSaleMenuData(List<StoreResponseDto.GetOnSaleStoreDataDto> getOnSaleStoreDataDtoList);
 }

--- a/src/main/java/Bob_BE/domain/store/repository/StoreCustomRepositoryImpl.java
+++ b/src/main/java/Bob_BE/domain/store/repository/StoreCustomRepositoryImpl.java
@@ -49,6 +49,31 @@ public class StoreCustomRepositoryImpl implements StoreCustomRepository {
     }
 
     @Override
+    public List<StoreResponseDto.StoreAndDiscountDataDto> GetOnSaleStore(University university) {
+
+        QStore store = QStore.store;
+        QDiscount discount = QDiscount.discount;
+        QDiscountMenu discountMenu = QDiscountMenu.discountMenu;
+        QStoreUniversity storeUniversity = QStoreUniversity.storeUniversity;
+
+        List<StoreResponseDto.StoreAndDiscountDataDto> results = queryFactory
+                .select(Projections.constructor(StoreResponseDto.StoreAndDiscountDataDto.class,
+                        store,
+                        discount))
+                .from(store)
+                .leftJoin(store.discountList, discount)
+                .leftJoin(discount.discountMenuList, discountMenu)
+                .leftJoin(store.storeUniversityList, storeUniversity)
+                .groupBy(store)
+                .orderBy(discountMenu.discountPrice.max().desc())
+                .where(storeUniversity.university.eq(university)
+                        .and(discount.inProgress.isTrue()))
+                .fetch();
+
+        return results;
+    }
+
+    @Override
     public List<StoreResponseDto.GetOnSaleStoreDataDto> GetOnSaleMenuData(List<StoreResponseDto.GetOnSaleStoreDataDto> getOnSaleStoreDataDtoList) {
 
         QDiscount discount = QDiscount.discount;

--- a/src/main/java/Bob_BE/domain/student/service/StudentService.java
+++ b/src/main/java/Bob_BE/domain/student/service/StudentService.java
@@ -135,7 +135,7 @@ public class StudentService {
         University university = student.getUniversity();
         List<StoreResponseDto.GetOnSaleStoreInMyPageDto> getOnSaleStoreDataDtos = null;
         if(university != null){
-            List<StoreResponseDto.StoreAndDiscountDataDto> saleStoreAndDiscount = storeRepository.GetOnSaleStoreAndDiscount(university);
+            List<StoreResponseDto.StoreAndDiscountDataDto> saleStoreAndDiscount = storeRepository.GetOnSaleStore(university);
             getOnSaleStoreDataDtos = StoreConverter.toGetOnSaleStoreInMyPageDtoList(saleStoreAndDiscount);
         }
 


### PR DESCRIPTION
## 연관된 이슈
> ex) #94


</br>

## 작업내용
>마이페이지 오늘의 할인가게 수정
할인율이 높은 식당들로 정렬되고,
식당들로 그룹되게 구성


</br>

## 데이터베이스 결과
```json
{
  "isSuccess": true,
  "code": "COMMON200",
  "message": "성공입니다.",
  "result": {
    "isUniversityExist": true,
    "university": {
      "universityName": "인하대학교",
      "universityAddress": "인천광역시 미추홀구 인하로163번길 22"
    },
    "todayMenus": [
      {
        "storeId": 1,
        "storeName": "금산양꼬치 본점",
        "discountId": 11,
        "discountTitle": "테스트"
      },
      {
        "storeId": 18,
        "storeName": "춘리마라탕 인하대점",
        "discountId": 24,
        "discountTitle": "마라탕 할인"
      }
    ],
    "account": {
      "name": "최원준",
      "email": "wonjundero@gmail.com"
    }
  }
}
```
