### PR TITLE
[REFACTOR] 상세 가게 페이지 응답 수정

### DIFF
--- a/src/main/java/Bob_BE/domain/menu/service/MenuService.java
+++ b/src/main/java/Bob_BE/domain/menu/service/MenuService.java
@@ -91,7 +91,7 @@ public class MenuService {
      * 가게 상세 페이지 API : 메뉴 데이터 가져오기
      * return : List<GetStoreMenuDataDto>
      */
-    public List<StoreResponseDto.GetStoreMenuDataDto> GetStoreMenuData(StoreParameterDto.GetStoreDataParamDto param) {
+    public List<StoreResponseDto.StoreMenuData> GetStoreMenuData(StoreParameterDto.GetStoreDataParamDto param) {
 
         Store findStore = storeRepository.findById(param.getStoreId())
                 .orElseThrow(() -> new StoreHandler(ErrorStatus.STORE_NOT_FOUND));

--- a/src/main/java/Bob_BE/domain/store/controller/StoreController.java
+++ b/src/main/java/Bob_BE/domain/store/controller/StoreController.java
@@ -178,8 +178,8 @@ public class StoreController {
 
         StoreParameterDto.GetStoreDataParamDto getStoreDataParamDto = StoreDtoConverter.INSTANCE.toGetStoreDataParamDto(storeId);
         Store findStore = storeService.GetStoreData(getStoreDataParamDto);
-        List<StoreResponseDto.GetStoreMenuDataDto> getStoreMenuDataDtoList = menuService.GetStoreMenuData(getStoreDataParamDto);
-        return ApiResponse.onSuccess(StoreConverter.toGetStoreDataResponseDto(findStore, getStoreMenuDataDtoList));
+        List<StoreResponseDto.StoreMenuData> storeMenuDataList = menuService.GetStoreMenuData(getStoreDataParamDto);
+        return ApiResponse.onSuccess(StoreConverter.toGetStoreDataResponseDto(findStore, storeMenuDataList));
     }
 
     @PostMapping("/{storeId}/operating_hours")

--- a/src/main/java/Bob_BE/domain/store/converter/StoreConverter.java
+++ b/src/main/java/Bob_BE/domain/store/converter/StoreConverter.java
@@ -56,7 +56,7 @@ public class StoreConverter {
                 .build();
     }
 
-    public static StoreResponseDto.GetStoreDataResponseDto toGetStoreDataResponseDto(Store store, List<StoreResponseDto.GetStoreMenuDataDto> getStoreMenuDataDtoList) {
+    public static StoreResponseDto.GetStoreDataResponseDto toGetStoreDataResponseDto(Store store, List<StoreResponseDto.StoreMenuData> storeMenuDataList) {
 
         List<String> bannerUrlList = store.getBannerList().stream()
                 .map(Banner::getBannerUrl)
@@ -67,13 +67,20 @@ public class StoreConverter {
 
         Discount discount = new Discount();
 
-
-
         if (onSale) {
             discount = store.getDiscountList().stream()
                     .filter(Discount::getInProgress)
                     .collect(Collectors.toList()).get(0);
+
+
         }
+
+        StoreResponseDto.StoreDiscountData storeDiscountData = StoreResponseDto.StoreDiscountData.builder()
+                .discountId(discount.getId())
+                .title(discount.getTitle())
+                .startDate(discount.getStartDate())
+                .endDate(discount.getEndDate())
+                .build();
 
         return StoreResponseDto.GetStoreDataResponseDto.builder()
                 .storeId(store.getId())
@@ -82,17 +89,14 @@ public class StoreConverter {
                 .storeLink(store.getStoreLink())
                 .signatureMenuId(store.getSignatureMenu().getMenu().getId())
                 .bannerUrlList(bannerUrlList)
-                .discountId(discount.getId())
-                .discountTitle(discount.getTitle())
-                .discountStartDate(discount.getStartDate())
-                .discountEndDate(discount.getEndDate())
-                .getStoreMenuDataDtoList(getStoreMenuDataDtoList)
+                .storeDiscountData(storeDiscountData)
+                .storeMenuDataList(storeMenuDataList)
                 .build();
     }
 
-    public static StoreResponseDto.GetStoreMenuDataDto toGetStoreMenuDataDto(Menu menu, int discountPrice, int discountRate) {
+    public static StoreResponseDto.StoreMenuData toGetStoreMenuDataDto(Menu menu, int discountPrice, int discountRate) {
 
-        return StoreResponseDto.GetStoreMenuDataDto.builder()
+        return StoreResponseDto.StoreMenuData.builder()
                 .menuId(menu.getId())
                 .menuName(menu.getMenuName())
                 .menuUrl(menu.getMenuUrl())

--- a/src/main/java/Bob_BE/domain/store/converter/StoreConverter.java
+++ b/src/main/java/Bob_BE/domain/store/converter/StoreConverter.java
@@ -65,6 +65,16 @@ public class StoreConverter {
         Boolean onSale = store.getDiscountList().stream()
                 .anyMatch(Discount::getInProgress);
 
+        Discount discount = new Discount();
+
+
+
+        if (onSale) {
+            discount = store.getDiscountList().stream()
+                    .filter(Discount::getInProgress)
+                    .collect(Collectors.toList()).get(0);
+        }
+
         return StoreResponseDto.GetStoreDataResponseDto.builder()
                 .storeId(store.getId())
                 .storeName(store.getName())
@@ -72,6 +82,10 @@ public class StoreConverter {
                 .storeLink(store.getStoreLink())
                 .signatureMenuId(store.getSignatureMenu().getMenu().getId())
                 .bannerUrlList(bannerUrlList)
+                .discountId(discount.getId())
+                .discountTitle(discount.getTitle())
+                .discountStartDate(discount.getStartDate())
+                .discountEndDate(discount.getEndDate())
                 .getStoreMenuDataDtoList(getStoreMenuDataDtoList)
                 .build();
     }

--- a/src/main/java/Bob_BE/domain/store/dto/response/StoreResponseDto.java
+++ b/src/main/java/Bob_BE/domain/store/dto/response/StoreResponseDto.java
@@ -176,18 +176,27 @@ public class StoreResponseDto {
         private Boolean onSale;
         private Long signatureMenuId;
         private List<String> bannerUrlList;
-        private Long discountId;
-        private String discountTitle;
-        private LocalDate discountStartDate;
-        private LocalDate discountEndDate;
-        private List<GetStoreMenuDataDto> getStoreMenuDataDtoList;
+        private StoreDiscountData storeDiscountData;
+        private List<StoreMenuData> storeMenuDataList;
     }
 
-    @Getter 
-    @Builder 
-    @NoArgsConstructor 
+    @Getter
+    @Builder
+    @NoArgsConstructor
     @AllArgsConstructor
-    public static class GetStoreMenuDataDto {
+    public static class StoreDiscountData {
+
+        private Long discountId;
+        private String title;
+        private LocalDate startDate;
+        private LocalDate endDate;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class StoreMenuData {
 
         private Long menuId;
         private String menuName;

--- a/src/main/java/Bob_BE/domain/store/dto/response/StoreResponseDto.java
+++ b/src/main/java/Bob_BE/domain/store/dto/response/StoreResponseDto.java
@@ -7,6 +7,7 @@ import com.querydsl.core.annotations.QueryProjection;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -175,6 +176,10 @@ public class StoreResponseDto {
         private Boolean onSale;
         private Long signatureMenuId;
         private List<String> bannerUrlList;
+        private Long discountId;
+        private String discountTitle;
+        private LocalDate discountStartDate;
+        private LocalDate discountEndDate;
         private List<GetStoreMenuDataDto> getStoreMenuDataDtoList;
     }
 


### PR DESCRIPTION
## 연관된 이슈
> #99 


</br>

## 작업내용
> 가게 상세 페이지 API 응답에 discount 관련 데이터 추가했습니다.

</br>

## 데이터베이스 결과
```json
{
  "isSuccess": true,
  "code": "COMMON200",
  "message": "성공입니다.",
  "result": {
    "storeId": 15,
    "storeName": "김치찌개",
    "storeLink": "https",
    "onSale": true,
    "signatureMenuId": 24,
    "bannerUrlList": [
      "https://bab-e-deuk-bucket.s3.ap-northeast-2.amazonaws.com/Banners/8ec581e2-053e-465e-84d4-7a3fad58b6e7-%E1%84%8B%E1%85%B5%E1%84%80%E1%85%A6%20%E1%84%8D%E1%85%B5%E1%86%AB%E1%84%8B%E1%85%B5%E1%86%B8%E1%84%82%E1%85%B5%E1%84%83%E1%85%A1.png"
    ],
    "storeDiscountData": {
      "discountId": 47,
      "title": "dmdekqdpxmtmldlqslek",
      "startDate": "2024-08-14",
      "endDate": "2024-08-16"
    },
    "storeMenuDataList": [
      {
        "menuId": 24,
        "menuName": "배가고파요",
        "menuUrl": "string",
        "menuPrice": 5000,
        "discountPrice": 500,
        "discountRate": 10
      }
    ]
  }
}
```
