### PR TITLE
[FIX] signature menu exception

### DIFF
--- a/src/main/java/Bob_BE/domain/menu/repository/MenuCustomRepository.java
+++ b/src/main/java/Bob_BE/domain/menu/repository/MenuCustomRepository.java
@@ -1,0 +1,9 @@
+package Bob_BE.domain.menu.repository;
+
+import Bob_BE.domain.menu.entity.Menu;
+import Bob_BE.domain.store.entity.Store;
+
+public interface MenuCustomRepository {
+
+    Menu GetMaxPriceMenuByStore(Store store);
+}

--- a/src/main/java/Bob_BE/domain/menu/repository/MenuCustomRepositoryImpl.java
+++ b/src/main/java/Bob_BE/domain/menu/repository/MenuCustomRepositoryImpl.java
@@ -1,0 +1,30 @@
+package Bob_BE.domain.menu.repository;
+
+import Bob_BE.domain.menu.entity.Menu;
+import Bob_BE.domain.menu.entity.QMenu;
+import Bob_BE.domain.store.entity.Store;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class MenuCustomRepositoryImpl implements MenuCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public MenuCustomRepositoryImpl(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+
+    @Override
+    public Menu GetMaxPriceMenuByStore(Store store) {
+
+        QMenu menu = QMenu.menu;
+
+        return queryFactory
+                .selectFrom(menu)
+                .where(menu.store.eq(store))
+                .orderBy(menu.price.desc())
+                .limit(1)
+                .fetchOne();
+    }
+}

--- a/src/main/java/Bob_BE/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/Bob_BE/domain/menu/repository/MenuRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.Optional;
 
-public interface MenuRepository extends JpaRepository<Menu, Long> {
+public interface MenuRepository extends JpaRepository<Menu, Long>, MenuCustomRepository {
 
     Optional<List<Menu>> findAllByStore(Store store);
 }

--- a/src/main/java/Bob_BE/domain/store/converter/StoreConverter.java
+++ b/src/main/java/Bob_BE/domain/store/converter/StoreConverter.java
@@ -7,6 +7,7 @@ import Bob_BE.domain.discountMenu.entity.DiscountMenu;
 import Bob_BE.domain.menu.dto.response.MenuResponseDto.SearchMenuResponseDto;
 import Bob_BE.domain.menu.entity.Menu;
 
+import Bob_BE.domain.signatureMenu.entity.SignatureMenu;
 import Bob_BE.domain.store.dto.response.StoreResponseDto.GetStoreSearchDto;
 import java.util.ArrayList;
 import java.time.LocalDateTime;
@@ -91,12 +92,15 @@ public class StoreConverter {
                 .endDate(discount.getEndDate())
                 .build();
 
+        SignatureMenu signatureMenu = new SignatureMenu();
+        if (store.getSignatureMenu() != null) signatureMenu = store.getSignatureMenu();
+
         return StoreResponseDto.GetStoreDataResponseDto.builder()
                 .storeId(store.getId())
                 .storeName(store.getName())
                 .onSale(onSale)
                 .storeLink(store.getStoreLink())
-                .signatureMenuId(store.getSignatureMenu().getMenu().getId())
+                .signatureMenuId(signatureMenu.getMenu().getId())
                 .bannerUrl(bannerUrl)
                 .storeDiscountData(storeDiscountData)
                 .storeMenuDataList(storeMenuDataList)

--- a/src/main/java/Bob_BE/domain/store/converter/StoreConverter.java
+++ b/src/main/java/Bob_BE/domain/store/converter/StoreConverter.java
@@ -46,6 +46,18 @@ public class StoreConverter {
 
     public static StoreResponseDto.StoreDataDto toStoreDataDto (Store store, Menu menu, int discountPrice) {
 
+        if (menu == null) {
+
+            return StoreResponseDto.StoreDataDto.builder()
+                    .storeId(store.getId())
+                    .storeName(store.getName())
+                    .latitude(store.getLatitude())
+                    .longitude(store.getLongitude())
+                    .menuPrice(0)
+                    .discountPrice(discountPrice)
+                    .build();
+        }
+
         return StoreResponseDto.StoreDataDto.builder()
                 .storeId(store.getId())
                 .storeName(store.getName())
@@ -89,18 +101,35 @@ public class StoreConverter {
                 .build();
 
         SignatureMenu signatureMenu = new SignatureMenu();
-        if (store.getSignatureMenu() != null) signatureMenu = store.getSignatureMenu();
 
-        return StoreResponseDto.GetStoreDataResponseDto.builder()
-                .storeId(store.getId())
-                .storeName(store.getName())
-                .onSale(onSale)
-                .storeLink(store.getStoreLink())
-                .signatureMenuId(signatureMenu.getMenu().getId())
-                .bannerUrl(bannerUrl)
-                .storeDiscountData(storeDiscountData)
-                .storeMenuDataList(storeMenuDataList)
-                .build();
+        if (store.getSignatureMenu() != null) {
+
+            signatureMenu = store.getSignatureMenu();
+
+            return StoreResponseDto.GetStoreDataResponseDto.builder()
+                    .storeId(store.getId())
+                    .storeName(store.getName())
+                    .onSale(onSale)
+                    .storeLink(store.getStoreLink())
+                    .signatureMenuId(signatureMenu.getMenu().getId())
+                    .bannerUrl(bannerUrl)
+                    .storeDiscountData(storeDiscountData)
+                    .storeMenuDataList(storeMenuDataList)
+                    .build();
+        }
+        else {
+
+            return StoreResponseDto.GetStoreDataResponseDto.builder()
+                    .storeId(store.getId())
+                    .storeName(store.getName())
+                    .onSale(onSale)
+                    .storeLink(store.getStoreLink())
+                    .signatureMenuId(0L)
+                    .bannerUrl(bannerUrl)
+                    .storeDiscountData(storeDiscountData)
+                    .storeMenuDataList(storeMenuDataList)
+                    .build();
+        }
     }
 
     public static StoreResponseDto.StoreMenuData toGetStoreMenuDataDto(Menu menu, int discountPrice, int discountRate) {

--- a/src/main/java/Bob_BE/domain/store/service/StoreService.java
+++ b/src/main/java/Bob_BE/domain/store/service/StoreService.java
@@ -38,6 +38,7 @@ import Bob_BE.global.response.exception.handler.*;
 import Bob_BE.global.util.JwtTokenProvider;
 import Bob_BE.global.util.aws.S3StorageService;
 import java.io.IOException;
+import java.security.SignatureException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -264,26 +265,48 @@ public class StoreService {
 
         return storeList.stream()
                 .map(store -> {
-                    if(store.getDiscountList().stream().anyMatch(Discount::getInProgress)) {
-                        AtomicInteger discountPrice = new AtomicInteger();
+                    // 할인을 하는 가게
+                    if (store.getDiscountList().stream().anyMatch(Discount::getInProgress)) {
+                        // 할인을 하는 가게 + 대표 메뉴가 설정되어 있는 가게
+                        if (store.getSignatureMenu() != null) {
 
-                        store.getSignatureMenu().getMenu().getDiscountMenuList()
-                                .forEach(discountMenu -> {
+                            AtomicInteger discountPrice = new AtomicInteger();
 
-                                    if(discountMenu.getDiscount().getInProgress())
-                                        discountPrice.addAndGet(discountMenu.getDiscountPrice());
-                                });
+                            store.getSignatureMenu().getMenu().getDiscountMenuList()
+                                    .forEach(discountMenu -> {
 
-                        if (discountPrice.get() == 0) {
+                                        if(discountMenu.getDiscount().getInProgress())
+                                            discountPrice.addAndGet(discountMenu.getDiscountPrice());
+                                    });
+
+                            if (discountPrice.get() == 0) {
+
+                                DiscountMenu discountMenu = discountMenuRepository.GetDiscountMenuByStoreAndMaxDiscountPrice(store);
+
+                                return StoreConverter.toStoreDataDto(store, discountMenu.getMenu(), discountMenu.getDiscountPrice());
+                            }
+
+                            return StoreConverter.toStoreDataDto(store, store.getSignatureMenu().getMenu(),discountPrice.get());
+                        }
+                        else { // 할인을 하는 가게 + 대표 메뉴가 설정되어 있지 않은 가게
+
                             DiscountMenu discountMenu = discountMenuRepository.GetDiscountMenuByStoreAndMaxDiscountPrice(store);
 
                             return StoreConverter.toStoreDataDto(store, discountMenu.getMenu(), discountMenu.getDiscountPrice());
                         }
-
-                        return StoreConverter.toStoreDataDto(store, store.getSignatureMenu().getMenu(),discountPrice.get());
                     }
-                    else {
-                        return StoreConverter.toStoreDataDto(store, store.getSignatureMenu().getMenu(), 0);
+                    else { // 할인을 하지 않는 가게
+
+                        if (store.getSignatureMenu() != null) { // 할인을 하지 않는 가게 + 대표 메뉴가 설정되어 있는 가게
+
+                            return StoreConverter.toStoreDataDto(store, store.getSignatureMenu().getMenu(), 0);
+                        }
+                        else { // 할인을 하지 않는 가게 + 대표 메뉴가 설정되어 있지 않은 가게
+
+                            Menu menu = menuRepository.GetMaxPriceMenuByStore(store);
+
+                            return StoreConverter.toStoreDataDto(store, menu, 0);
+                        }
                     }
                 }).toList();
     }

--- a/src/main/java/Bob_BE/global/response/code/resultCode/ErrorStatus.java
+++ b/src/main/java/Bob_BE/global/response/code/resultCode/ErrorStatus.java
@@ -48,6 +48,9 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // S3 Storage
     FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3BUCKET500", "파일 업로드에 실패했습니다."),
+
+    // SignatureMenu
+    SIGNATURE_MENU_NOT_EXIST(HttpStatus.NOT_FOUND, "SIGNATURE401", "해당 가게의 대표 메뉴가 설정되어 있지 않습니다."),
     ;
 
 

--- a/src/main/java/Bob_BE/global/response/exception/handler/SignatureMenuHandler.java
+++ b/src/main/java/Bob_BE/global/response/exception/handler/SignatureMenuHandler.java
@@ -1,0 +1,11 @@
+package Bob_BE.global.response.exception.handler;
+
+import Bob_BE.global.response.code.BaseErrorCode;
+import Bob_BE.global.response.exception.GeneralException;
+
+public class SignatureMenuHandler extends GeneralException {
+
+    public SignatureMenuHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}


### PR DESCRIPTION
## 연관된 이슈
#133


</br>

## 작업내용
대표메뉴가 없거나 메뉴가 없거나 하는 상황 발생 (프론트 측이든 백엔드 측이든 테스트 시 잘못된 데이터 입력 순서로 인한 문제) 으로 지속적인 NULL에러가 발생하여 null일 경우 처리 코드 추가

</br>

## 데이터베이스 결과
```json
{
  "isSuccess": true,
  "code": "COMMON200",
  "message": "성공입니다.",
  "result": {
    "storeId": 46,
    "storeName": "ㅇ",
    "storeLink": "ㅇ",
    "onSale": false,
    "signatureMenuId": 0,
    "bannerUrl": "https://bab-e-deuk-bucket.s3.ap-northeast-2.amazonaws.com/Banners/ba0fba6f-82ed-4b02-8c36-7c135739dc29-Frame%201707482344.jpg",
    "storeDiscountData": {
      "discountId": null,
      "title": null,
      "startDate": null,
      "endDate": null
    },
    "storeMenuDataList": []
  }
}
```
