### PR TITLE
[FIX] 가게 정보에서 가게 링크 가져오기 추가

### DIFF
--- a/src/main/java/Bob_BE/domain/store/converter/StoreConverter.java
+++ b/src/main/java/Bob_BE/domain/store/converter/StoreConverter.java
@@ -296,6 +296,7 @@ public class StoreConverter {
                 .bannerImageUrl(bannerUrl)
                 .storeUniversity(university.getUniversityName())
                 .storeAddress(store.getStreetAddress())
+                .storeLink(store.getStoreLink())
                 .build();
     }
 }

--- a/src/main/java/Bob_BE/domain/store/dto/response/StoreResponseDto.java
+++ b/src/main/java/Bob_BE/domain/store/dto/response/StoreResponseDto.java
@@ -241,5 +241,6 @@ public class StoreResponseDto {
         private String bannerImageUrl;
         private String storeUniversity;
         private String storeAddress;
+        private String storeLink;
     }
 }


### PR DESCRIPTION
## 연관된 이슈
> #146 


</br>

## 작업내용
> 가게 정보 가져오기 API에서 가게의 LINK를 가져옵니다. 링크가 없는 경우  NULL을 반환합니다!

</br>

## 데이터베이스 결과
> 코드 블럭 <json>으로 보여주세요.

```json
{
  "isSuccess": true,
  "code": "COMMON200",
  "message": "성공입니다.",
  "result": {
    "storeId": 20,
    "storeName": "동아리닭갈비",
    "bannerImageUrl": "https://bab-e-deuk-bucket.s3.ap-northeast-2.amazonaws.com/Banners/5%EB%8F%99%EC%95%84%EB%A6%AC%EB%8B%AD%EA%B0%88%EB%B9%84_%EB%B0%B0%EB%84%88.png",
    "storeUniversity": "인하대학교",
    "storeAddress": "인천 미추홀구 경인남길30번길 71 1층",
    "storeLink": null
  }
}
```
