### PR TITLE
fix: 사장 로그인 응답 수정

### DIFF
--- a/src/main/java/Bob_BE/domain/owner/service/OwnerService.java
+++ b/src/main/java/Bob_BE/domain/owner/service/OwnerService.java
@@ -68,7 +68,7 @@ public class OwnerService {
 
             if (existingOwner.isPresent()) {
                 String jwt = jwtTokenProvider.createToken(existingOwner.get().getId(), ROLE);
-                Boolean isStoreExist = getOwnerStore(existingOwner.get()) != null;
+                Boolean isStoreExist = isOwnerStoreExist(existingOwner.get());
                 return OwnerResponseDto.LoginOrRegisterDto.builder()
                         .jwt(jwt)
                         .successStatus(SuccessStatus._OK)
@@ -137,5 +137,10 @@ public class OwnerService {
 
         return storeRepository.findFirstByOwnerId(owner.getId())
                 .orElse(new Store());
+    }
+
+    public Boolean isOwnerStoreExist(Owner owner) {
+
+        return storeRepository.findFirstByOwnerId(owner.getId()).orElse(null) != null;
     }
 }


### PR DESCRIPTION
## 연관된 이슈
> #152


</br>

## 작업내용
> 사장님 로그인시 최초에만 가게가 없다고 나오고,
이후에는 가게가 없음에도 가게가 있다고 나오는 문제 수정

</br>

## 데이터베이스 결과
> 응답 양식은 이전과 변경된 점이 없습니다.
```json
{
  "isSuccess": true,
  "code": "COMMON200",
  "message": "성공입니다.",
  "result": {
    "successStatus": "_OK",
    "jwt": "eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MTMsInJvbGUiOiJvd25lciIsImlhdCI6MTcyNDMzMzg0NCwiZXhwIjoxNzI0MzM3NDQ0fQ.OxDdpEgEa2gcRuMaWDhpu96jfxViqtPbWLazcvuwBJs",
    "kakaoNickname": "최원준",
    "kakaoEmail": "wonjundero@gmail.com",
    "role": "owner",
    "isStoreExist": false
  }
}
```
